### PR TITLE
Suggested changes for textmod

### DIFF
--- a/csgo_textmod.txt
+++ b/csgo_textmod.txt
@@ -37,20 +37,20 @@
     "Cstrike_TitlesTXT_Game_teammate_attack"            " %s1 attacked a teammate."
     "csgo_player_left_game"                             " %s1 left (%s2)"
 
-    "Cstrike_TitlesTXT_Defusing_Bomb"                   " • Defusing"
-    "Cstrike_TitlesTXT_Planting_Bomb"                   " • Planting"
+    "Cstrike_TitlesTXT_Defusing_Bomb"                   " Defusing"
+    "Cstrike_TitlesTXT_Planting_Bomb"                   " Planting"
 
     // Grenade radio
-    "SFUI_TitlesTXT_Fire_in_the_hole"                   " • Grenade"
-    "SFUI_TitlesTXT_Molotov_in_the_hole"                " • Molotov"
-    "SFUI_TitlesTXT_Incendiary_in_the_hole"             " • Incendiary"
-    "SFUI_TitlesTXT_Flashbang_in_the_hole"              " • Flash"
-    "SFUI_TitlesTXT_Smoke_in_the_hole"                  " • Smoke"
-    "SFUI_TitlesTXT_Decoy_in_the_hole"                  " • Decoy"
+    "SFUI_TitlesTXT_Fire_in_the_hole"                   " Grenade"
+    "SFUI_TitlesTXT_Molotov_in_the_hole"                " Molotov"
+    "SFUI_TitlesTXT_Incendiary_in_the_hole"             " Incendiary"
+    "SFUI_TitlesTXT_Flashbang_in_the_hole"              " Flash"
+    "SFUI_TitlesTXT_Smoke_in_the_hole"                  " Smoke"
+    "SFUI_TitlesTXT_Decoy_in_the_hole"                  " Decoy"
 
     // Chat messages
-    "Game_radio"                                        "%s1 (RADIO): %s2"
-    "Game_radio_location"                               "%s1 @ %s2 (RADIO): %s3"
+    "Game_radio"                                        "%s1 (RADIO) • %s2"
+    "Game_radio_location"                               "%s1 @ %s2 (RADIO) • %s3"
     "Cstrike_Chat_CT_Loc"                               "%s1 @ %s3 (Team): %s2"
     "Cstrike_Chat_T_Loc"                                "%s1 @ %s3 (Team): %s2"
     "Cstrike_Chat_CT_Dead"                              " *DEAD* %s1 (Team): %s2"
@@ -58,7 +58,7 @@
     "Cstrike_Chat_CT"                                   "%s1 (Team): %s2"
     "Cstrike_Chat_T"                                    "%s1 (Team): %s2"
     "Cstrike_Chat_All"                                  "%s1: %s2"
-    "Cstrike_Chat_AllDead"                              " *DEAD* %s1: %s2"
+    "Cstrike_Chat_AllDead"                              " *DEAD* %s1: %s2"
 
     // Player awards
     "Player_Cash_Award_Bomb_Defused"                    " +$%s1 • Bomb defused"


### PR DESCRIPTION
Changes:
- Added punctuation to various strings.
- Miscellaneous changes to various strings.
- Added a space before every color code to make sure they work.
- Removed `CSGO_Spray_Auto_Toggle`. The original one has useful information (original: `Quick Graffiti (apply graffiti with key release)`).
- Added `•` to defusing and planting strings, like the grenade ones. Fits better in my opinion.
- Made the chat messages more similar to Valve's current format while keeping the new colors.
- Removed unused strings (spectator strings).
- Removed (probably) unused hostage strings (I presume they're from CS:S).
- Removed plus sign for messages where the player neither receives nor loses money.